### PR TITLE
.NETバージョンを8.0.xに更新

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -26,8 +26,11 @@ jobs:
           6.0.x
           8.0.x
 
+    - name: install android workload
+      run: dotnet workload install android
+
     - name: restore
-      run: dotnet restore OpenUtau -r ${{ matrix.os.arch }}
+      run: dotnet restore OpenUtau.Desktop -r ${{ matrix.os.arch }}
 
     - name: test
       run: dotnet test OpenUtau.Test


### PR DESCRIPTION
`pr-test.yml`ファイルで、Androidワークロードのインストールステップを追加し、`OpenUtau`プロジェクトのリストアコマンドが`OpenUtau.Desktop`にも適用されるようにしました。テストの実行に関しては変更はありません。