### PR TITLE
Added font settings for macOS

### DIFF
--- a/OpenUtau/Program.cs
+++ b/OpenUtau/Program.cs
@@ -67,6 +67,10 @@ namespace OpenUtau.App {
                     string [] fontFamilies = fontFamily.Split(',');
                     fontOptions.DefaultFamilyName = fontFamilies[0];
                 }
+            } else if (OS.IsMacOS()) {
+                //To avoid text display corruption, specify Hiragino Sans characters first.
+                //Due to the specification of AvaloniaUI, this only affects when the language is set to Japanese.
+                fontOptions.DefaultFamilyName = "Hiragino Sans, Segoe UI, San Francisco, Helvetica Neue";
             }
             return AppBuilder.Configure<App>()
                 .UsePlatformDetect()


### PR DESCRIPTION
Added font settings for macOS

In the `BuildAvaloniaApp` method, we added code to specify a specific font family for macOS. This will use the fonts ‘Hiragino Sans, Segoe UI, San Francisco, Helvetica Neue’ to avoid text display corruption when Japanese is set.